### PR TITLE
standardizing Spanish wg-risk

### DIFF
--- a/spanish/wg-risk/README.md
+++ b/spanish/wg-risk/README.md
@@ -1,0 +1,13 @@
+# Focus Areas
+
+The risk metrics are organized in focus areas:
+
+| Focus Area | Goal |
+| --- | --- |
+|1. [Business Risk](business-risk) | Understand how active a community exists around/to support a given software package. |
+|2. [Code Quality](code-quality) | Understand the quality of a given software package.|
+|3. [Licensing](licensing) | Understand the potential IP issues associated with a given software package’s use.|
+|4. [Security](security) | Understand security processes and procedures associated with the software’s development.|
+|5. [Transparency](transparency) | Understand how transparent a given software package is with respect to dependencies, licensing (?), security processes, etc.|
+
+> This README needs to be translated to Spanish

--- a/spanish/wg-risk/business-risk/README.md
+++ b/spanish/wg-risk/business-risk/README.md
@@ -1,0 +1,15 @@
+# Business Risk
+
+**Goal:** Understand how active a community exists around/to support a given software package.
+
+Metric | Question
+--- | ---
+[Average issue Resolution Time](average-issue-resolution-time.md) | How long does it take for an issue to be resolved?
+[Bus Factor](bus-factor.md)| How high is the risk to a project should the most active people leave?
+[Committers](committers.md) | How robust are the contributors to a community?
+[Elephant Factor](elephant-factor.md)| What is the distribution of work in the community?
+[Issues Open Age](issues-open-age.md) | How long is an issue open for before it is closed?
+[Issues Volume](issues-volume.md)| What is the volume of open issues?
+[Lines of Code](lines-of-code.md)| How many lines of code have been contributed?
+
+> This README needs to be translated to Spanish

--- a/spanish/wg-risk/business-risk/committers.md
+++ b/spanish/wg-risk/business-risk/committers.md
@@ -3,6 +3,7 @@
 Pregunta: ¿Cómo de sólidos son los contribuyentes de una comunidad?
 
 ## Descripción
+
 La métrica Committers es el número de personas que han contribuido con «commits» de código en un proyecto. Esta métrica es distinta de la [métrica de CHAOSS más amplia «Contribuyentes»](https://github.com/chaoss/wg-common/blob/master/focus-areas/who/contributors.md), que habla directamente de la única preocupación específica que surge en la evaluación del riesgo por parte de los administradores que deciden qué proyecto de código abierto utilizar.  Si bien no es necesariamente cierto en todos los casos, en general se acepta que cuantos más contribuyentes tenga un proyecto, más probable será que ese proyecto continúe recibiendo actualizaciones, soporte y recursos necesarios. Por lo tanto, la métrica permite a las organizaciones tomar una decisión informada sobre si el número de committers de un proyecto determinado presenta potencialmente un riesgo actual o futuro de que el proyecto pueda ser abandonado o que quede con poco soporte.
 
 ## Objetivos
@@ -26,16 +27,19 @@ De Grimoire Lab mostrando committers
 ![Grimoire Lab Committers](images/committers_grimoire-lab.png)
 
 ### Filtros
+
 * Tiempo: conocer el número más reciente de committers distintos puede indicar más claramente el número de personas que participan en un proyecto que examinar el número durante la vida de un proyecto (repositorio).
 * Tamaño de commit: las confirmaciones pequeñas, medidas por líneas de código, podrían excluirse para evitar un problema conocido
 * Cantidad de commits: los contribuyentes con menos de un umbral mínimo de commit en un período de tiempo podrían ser excluidos de este número.
 
 ## Herramientas que proporcionan la métrica
+
 Augur mantiene una tabla para cada registro de commit en un repositorio.
 
 ![Augur Committers](images/committers_augur.png)
 
 Para evaluar los distintos committers de un repositorio, se pueden utilizar los siguientes endpoints SQL o API documentados:
+
 ```sql
 SELECT
     cmt_author_name,
@@ -55,4 +59,5 @@ Esta expresión permite a un usuario final filtrar por umbrales de recuento de c
 [Grimoire Lab](https://chaoss.biterg.io/app/kibana#/dashboard/Git) también proporciona información sobre los committers.
 
 ## Referencias
+
 1. Nora McDonald, Kelly Blincoe, Eva Petakovic y Sean Goggins. 2014. Modelado de colaboración distribuida en GitHub. Avances en sistemas complejos 17 (7 & 8).

--- a/spanish/wg-risk/business-risk/elephant-factor.md
+++ b/spanish/wg-risk/business-risk/elephant-factor.md
@@ -48,7 +48,9 @@ Si tenemos 8 organizaciones y cada una de las cuales contribuye con el siguiente
     * Seleccione el índice `git`
     * Tamaño de la porción de las métricas: Agregación `Cantidad`
     * Segmentos divididos en cubos: Agregación `Términos`, Campo `author_org_name`, Ordenar por `métrica: Cantidad`, Orden `Descendente`, Tamaño `500`
-  - Captura de pantalla de ejemplo: ![GrimoireLab 指标截图 Elephant_Factor](images/elephant-factor_grimoire-lab.png)
+  - Captura de pantalla de ejemplo: 
+  
+  ![GrimoireLab 指标截图 Elephant_Factor](images/elephant-factor_grimoire-lab.png)
 
 
 ## Referencias

--- a/spanish/wg-risk/code-quality/README.md
+++ b/spanish/wg-risk/code-quality/README.md
@@ -1,0 +1,11 @@
+# Code Quality
+
+**Goal:** Understand the quality of a given software package.
+
+Metric | Question
+--- | ---
+[Code Complexity](code-complexity.md) | How complex is the code?
+[Pull Request Process](pull-request-process.md)| What is the process of making a Pull Request?
+[Test Coverage](test-coverage.md) | How well is the code tested?
+
+> This README needs to be translated to Spanish

--- a/spanish/wg-risk/licensing/README.md
+++ b/spanish/wg-risk/licensing/README.md
@@ -1,0 +1,13 @@
+# Licensing
+
+**Goal:** Understand the potential IP issues associated with a given software package’s use.
+
+Metric | Question
+--- | ---
+[License Count](license-count.md) | How many different licenses are there?
+[License Coverage](license-coverage.md)| How much of the code base has declared licenses?
+[License Declared](license-declared.md) | What are the declared software package licenses?
+[OSI Approved Licenses](osi-approved-licenses.md)| What percentage of a project’s licenses are OSI approved open source licenses?
+[SPDX Document](spdx-document.md) |  Does the software package have an associated SPDX document as a standard expression of dependencies, licensing, and security-related issues?
+
+> This README needs to be translated to Spanish

--- a/spanish/wg-risk/licensing/license-coverage.md
+++ b/spanish/wg-risk/licensing/license-coverage.md
@@ -3,9 +3,11 @@
 Pregunta: ¿Qué parte del código base tiene licencias declaradas?
 
 ## Descripción
+
 Qué parte del código base tiene licencias declaradas que los escáneres pueden reconocer y que pueden no estar solo aprobadas por OSI. Esto incluye tanto los archivos fuente de software como de documentación y se representa como un porcentaje de la cobertura total.
 
 ## Objetivos
+
 La Cobertura de licencia proporciona información sobre el porcentaje de archivos en un paquete de software que tiene una licencia declarada, lo que lleva a dos casos de uso:
 1. Un paquete de software se obtiene para uso organizacional interno y la cobertura de licencia declarada puede resaltar puntos de interés o preocupación al usar ese paquete de software.
 2. Además, se proporciona un paquete de software a proyectos externos posteriores, y la cobertura de licencia declarada puede hacer transparente la información de licencia necesaria para la integración, implementación y uso posteriores.
@@ -13,6 +15,7 @@ La Cobertura de licencia proporciona información sobre el porcentaje de archivo
 ## Implementación
 
 ### Filtros
+
 Tiempo: las licencias declaradas en un repositorio pueden cambiar con el tiempo a medida que cambian las dependencias del repositorio. Una de las principales motivaciones para rastrear la presencia de licencias, además del conocimiento básico, es llamar la atención sobre cualquier introducción inesperada de una nueva licencia.
 
 ### Visualizaciones
@@ -26,10 +29,12 @@ Tiempo: las licencias declaradas en un repositorio pueden cambiar con el tiempo 
 ![Augur Web Output](images/license-coverage_augur-web-output.png)
 
 ### Herramientas que proporcionan la métrica
- 1. [Augur](https://github.com/chaoss/augur)
+
+1. [Augur](https://github.com/chaoss/augur)
 
 Los datos se pueden extraer y filtrar para obtener la información deseada. Los datos de cobertura de licencia se pueden encontrar en cualquier [página de riesgo de Augur](http://augur.osshealth.io/repo/Zephyr-RTOS/zephyr/risk)
 
 ## Referencias
+
 * https://spdx.org/
 * https://www.fossology.org

--- a/spanish/wg-risk/licensing/license-declared.md
+++ b/spanish/wg-risk/licensing/license-declared.md
@@ -3,6 +3,7 @@
 Pregunta: ¿Cuáles son las licencias declaradas del paquete de software?
 
 ## Descripción
+
 El número total y las licencias específicas declaradas en un paquete de software. Esto puede incluir archivos fuente de software y documentación. Esta métrica es una enumeración de licencias y la cantidad de archivos con esa declaración de licencia en particular. Por ejemplo:
 
 | Tipo de licencia de SPDX | Número de archivos con licencia |
@@ -13,6 +14,7 @@ El número total y las licencias específicas declaradas en un paquete de softwa
 
 
 ## Objetivos
+
 El número total y las licencias específicas declaradas es fundamental en varios casos:
 1. La invariabilidad de un paquete de software conlleva múltiples licencias de software y es fundamental en la adquisición de paquetes de software estar al tanto de las licencias declaradas por razones de cumplimiento. Las licencias declaradas pueden proporcionar transparencia para los esfuerzos de cumplimiento de licencias.
 2. Las licencias pueden crear conflictos de modo que no se puedan cumplir todas las obligaciones en todas las licencias de un paquete de software. Las licencias declaradas pueden proporcionar transparencia sobre posibles conflictos de licencias presentes en los paquetes de software.
@@ -20,6 +22,7 @@ El número total y las licencias específicas declaradas es fundamental en vario
 ## Implementación
 
 ### Filtros
+
 * Tiempo: las licencias declaradas en un repositorio pueden cambiar con el tiempo a medida que cambian las dependencias del repositorio. Una de las principales motivaciones para rastrear la presencia de licencias, además del conocimiento básico, es llamar la atención sobre cualquier introducción inesperada de una nueva licencia.
 * Declarada y no declarada: enumeración separada de archivos que tienen declaraciones de licencia y archivos que no las tienen.
 
@@ -39,5 +42,6 @@ El paquete Augur-SPDX se implementa como un complemento de Augur y utiliza este 
 * Las `licencias` están asociadas con `archivos` y `packages_files`. Cada `archivo` podría tener posiblemente más de una referencia de `licencias`, lo cual es posible bajo la condición de que la declaración de `licencias` cambie entre escaneos de `Augur-SPDX` del repositorio. Cada `paquete` se almacena en su forma más reciente, y cada `packages_file` puede tener una declaración de `licencia`.
 
 ## Referencias
+
 * https://spdx.org/
 * https://www.fossology.org

--- a/spanish/wg-risk/licensing/spdx-document.md
+++ b/spanish/wg-risk/licensing/spdx-document.md
@@ -3,9 +3,11 @@
 Pregunta: ¿Tiene el paquete de software un documento SPDX asociado como expresión estándar de dependencias, licencias y problemas relacionados con la seguridad?
 
 ## Descripción
+
 Un paquete de software tiene un documento SPDX asociado como expresión estándar de dependencias, licencias y problemas relacionados con la seguridad. Puede encontrar más información sobre la especificación SPDX en: https://spdx.org/
 
 ## Objetivos
+
 Para los gerentes que adquieren software de código abierto como parte de una cartera de TI o de la Oficina de programas de código abierto, un documento SPDX proporciona una pieza central cada vez más esencial de información de gestión.  Esto surge porque, dado que existen paquetes de software en cadenas de suministro de software complejas, es importante expresar de forma clara y estandarizada las dependencias asociadas, las licencias y los problemas relacionados con la seguridad con ese paquete de software. Un documento SPDX proporciona una única fuente de información tanto para uso interno como para la distribución posterior de paquetes de software. Un documento SPDX ayuda a determinar cómo las organizaciones rutinizan el trabajo de código abierto para integrarse mejor con sus propias rutinas de gestión de riesgos de código abierto.
 
 ## Implementación
@@ -36,10 +38,13 @@ Este documento fue generado por Augur.
 
 * Paquetes
 * Package_Files
-* Archivos (que pueden estar incluidos, pero es poco probable que también se incluyan en otros paquetes). La información de la licencia se incluye como parte de un SBOM, pero la complejidad de la identificación de la licencia se aclara en las métricas [License_Count](https://github.com/chaoss/wg-risk/blob/master/metrics/License_Count.md), [License_Coverage](https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md)y [License_Declared](https://github.com/chaoss/wg-risk/blob/master/metrics/License_Declared.md). ![SBOM](images/spdx-document_sbom.png)
+* Archivos (que pueden estar incluidos, pero es poco probable que también se incluyan en otros paquetes). La información de la licencia se incluye como parte de un SBOM, pero la complejidad de la identificación de la licencia se aclara en las métricas [License_Count](https://github.com/chaoss/wg-risk/blob/master/metrics/License_Count.md), [License_Coverage](https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md)y [License_Declared](https://github.com/chaoss/wg-risk/blob/master/metrics/License_Declared.md).
+
+![SBOM](images/spdx-document_sbom.png)
 
 
 ## Referencias
+
 * https://spdx.org
 * https://www.ntia.doc.gov/SoftwareTransparency  
 

--- a/spanish/wg-risk/security/README.md
+++ b/spanish/wg-risk/security/README.md
@@ -1,0 +1,11 @@
+# Security
+
+**Goal:** Understand security processes and procedures associated with the software’s development.
+
+Metric | Question
+--- | ---
+[CII Best Practices](cii-best-practices.md) | What is the current CII Best Practices status for the project?
+[Language Declaration README](language-declaration-readme.md)| How many languages were used?
+[Language Source Proportion](language-source-proportion.md) | What is the proportion of language souces used?
+
+> This README needs to be translated to Spanish

--- a/spanish/wg-risk/transparency/README.md
+++ b/spanish/wg-risk/transparency/README.md
@@ -1,0 +1,9 @@
+# Transparency 
+
+**Goal:** Understand how transparent a given software package is with respect to dependencies, licensing (?), security processes, etc. 
+
+Metric | Question
+--- | ---
+[Software Bill of Materials](software-bill-of-materials.md) | Does the software package have a standard expression of dependencies, licensing, and security-related issues?
+
+> This README needs to be translated to Spanish


### PR DESCRIPTION
The wg-risk for Spanish translations is missing the `focus-areas` table and individual READMEs for each focus-area.
Currently I've added them as per the English version as a placeholder. Each README contains a tag at the end that says -
> This README needs to be translated to Spanish

The metric markdowns are also modified according to the latest metric template.

Signed-off-by: ritik-malik <ritik18406@iiitd.ac.in>